### PR TITLE
Fix flags usage with raw command

### DIFF
--- a/src/commands/raw.ts
+++ b/src/commands/raw.ts
@@ -14,7 +14,11 @@ export default class Raw extends RpcCommand {
   static strict = false
 
   async run() {
-    const [id, ...argv] = this.argv.filter((arg, i, arr) => !arg.startsWith('-') && (!arr[i - 1].startsWith('-') || arr[i - 1].includes('=')))
+    const [id, ...argv] = this.argv.filter((arg, i, arr) => {
+      const isFlag = arg.startsWith('-')
+      const isFlagArgument = i > 0 ? arr[i - 1].startsWith('-') && !arr[i - 1].includes('=') : false
+      return !isFlag && !isFlagArgument
+    })
 
     const params = argv.map((arg, index) => {
       let parseNumber = true

--- a/src/commands/raw.ts
+++ b/src/commands/raw.ts
@@ -14,7 +14,7 @@ export default class Raw extends RpcCommand {
   static strict = false
 
   async run() {
-    const [id, ...argv] = this.argv.filter(arg => !arg.startsWith('-'))
+    const [id, ...argv] = this.argv.filter((arg, i, arr) => !arg.startsWith('-') && (!arr[i - 1].startsWith('-') || arr[i - 1].includes('=')))
 
     const params = argv.map((arg, index) => {
       let parseNumber = true


### PR DESCRIPTION
Fixes this bug where flag values (when separated from the flag with a space) would incorrectly be used as the RPC method name when using the raw command:

```
bin/run --host seed1.nimiq.local raw getVotingKey
    Error: Method not found: Method does not exist: seed5.nimiq.local
```