### PR TITLE
RPC Api Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ USAGE
 
 # Request Options
 ```sh-session
-  -t, --timeout        Timeout for request in ms, set to 0 to disable (default: 5000)
-  -m, --show-metadata  Show response metadata (default: false)
+  -t, --timeout   Timeout for request in ms, set to 0 to disable (default: 5000)
+  -m, --metadata  Show response metadata (default: false)
 ```
 
 # Commands

--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ USAGE
 
 # Request Options
 ```sh-session
-  -t, --timeout  Timeout for request in ms, set to 0 to disable (default: 5000)
+  -t, --timeout        Timeout for request in ms, set to 0 to disable (default: 5000)
+  -m, --show-metadata  Show response metadata (default: false)
 ```
 
 # Commands
@@ -85,7 +86,6 @@ USAGE
   $ arpl account:create
 
 OPTIONS
-  -m, --show-metadata  Show returned metadata
   --password=password  Password to encrypt the key
   --unlock             Unlock the account after creation
 ```
@@ -102,9 +102,6 @@ USAGE
 
 ARGUMENTS
   ADDRESS  Address of the account to follow
-
-OPTIONS
-  -m, --show-metadata  Show returned metadata
 ```
 
 _See code: [src/commands/account/follow.ts](https://github.com/sisou/arpl/blob/v0.8.2/src/commands/account/follow.ts)_
@@ -119,9 +116,6 @@ USAGE
 
 ARGUMENTS
   ADDRESS  Address of the account to display
-
-OPTIONS
-  -m, --show-metadata  Show returned metadata
 ```
 
 _See code: [src/commands/account/get.ts](https://github.com/sisou/arpl/blob/v0.8.2/src/commands/account/get.ts)_
@@ -138,7 +132,6 @@ ARGUMENTS
   PRIVATEKEY  Private key in HEX or Base64 format
 
 OPTIONS
-  -m, --show-metadata  Show returned metadata
   --password=password  Password to encrypt the key
   --unlock             Unlock the account after import
 ```
@@ -152,9 +145,6 @@ List accounts available in node
 ```
 USAGE
   $ arpl account:list
-
-OPTIONS
-  -m, --show-metadata  Show returned metadata
 ```
 
 _See code: [src/commands/account/list.ts](https://github.com/sisou/arpl/blob/v0.8.2/src/commands/account/list.ts)_
@@ -169,9 +159,6 @@ USAGE
 
 ARGUMENTS
   ADDRESS  Address of the account to lock
-
-OPTIONS
-  -m, --show-metadata  Show returned metadata
 ```
 
 _See code: [src/commands/account/lock.ts](https://github.com/sisou/arpl/blob/v0.8.2/src/commands/account/lock.ts)_
@@ -188,7 +175,6 @@ ARGUMENTS
   ADDRESS  Address to display transactions for
 
 OPTIONS
-  -m, --show-metadata     Show returned metadata
   -x, --extended          show extra columns
   --columns=columns       only show provided columns (comma-separated)
   --csv                   output is csv format [alias: --output=csv]
@@ -217,7 +203,6 @@ ARGUMENTS
   ADDRESS  Address of the account to unlock
 
 OPTIONS
-  -m, --show-metadata  Show returned metadata
   --password=password  Password to decrypt the key
 ```
 
@@ -230,9 +215,6 @@ Stream blocks live
 ```
 USAGE
   $ arpl block:follow
-
-OPTIONS
-  -m, --show-metadata  Show returned metadata
 ```
 
 _See code: [src/commands/block/follow.ts](https://github.com/sisou/arpl/blob/v0.8.2/src/commands/block/follow.ts)_
@@ -249,8 +231,7 @@ ARGUMENTS
   NUMBER_OR_HASH  [default: latest] Block number or hash of the block to get
 
 OPTIONS
-  -m, --show-metadata  Show returned metadata
-  --full               Include block body (transactions, etc.)
+  --full  Include block body (transactions, etc.)
 ```
 
 _See code: [src/commands/block/get.ts](https://github.com/sisou/arpl/blob/v0.8.2/src/commands/block/get.ts)_
@@ -279,9 +260,6 @@ Get the local peer ID of the node
 ```
 USAGE
   $ arpl peer:id
-
-OPTIONS
-  -m, --show-metadata  Show returned metadata
 ```
 
 _See code: [src/commands/peer/id.ts](https://github.com/sisou/arpl/blob/v0.8.2/src/commands/peer/id.ts)_
@@ -293,9 +271,6 @@ Run a raw Nimiq JSON-RPC command
 ```
 USAGE
   $ arpl raw COMMAND [OPTIONS]
-
-OPTIONS
-  -m, --show-metadata  Show returned metadata
 ```
 
 _See code: [src/commands/raw.ts](https://github.com/sisou/arpl/blob/v0.8.2/src/commands/raw.ts)_
@@ -327,7 +302,6 @@ ARGUMENTS
   VALUE   NIM amount to add
 
 OPTIONS
-  -m, --show-metadata              Show returned metadata
   --address=address                Staker address to add stake to (default: sender address)
   --dry                            Return serialized transaction without sending it
   --fee=fee                        Fee in Luna (default: 0)
@@ -351,8 +325,7 @@ ARGUMENTS
   STAKER_ADDRESS  Address of staker to show information for
 
 OPTIONS
-  -m, --show-metadata  Show returned metadata
-  --plain              Display plain command output
+  --plain  Display plain command output
 
 ALIASES
   $ arpl staker:get
@@ -369,8 +342,7 @@ USAGE
   $ arpl stake:list
 
 OPTIONS
-  -m, --show-metadata  Show returned metadata
-  --plain              Display plain command output
+  --plain  Display plain command output
 ```
 
 _See code: [src/commands/stake/list.ts](https://github.com/sisou/arpl/blob/v0.8.2/src/commands/stake/list.ts)_
@@ -388,7 +360,6 @@ ARGUMENTS
   NEW_VALIDATOR_ADDRESS  Address of the validator to move stake to
 
 OPTIONS
-  -m, --show-metadata              Show returned metadata
   --dry                            Return serialized transaction without sending it
   --fee=fee                        Fee in Luna (default: 0)
   --fee-wallet=fee-wallet          Address of unlocked account to pay the fee from (default: fee is paid from stake)
@@ -414,7 +385,6 @@ ARGUMENTS
   VALUE              NIM amount to stake
 
 OPTIONS
-  -m, --show-metadata              Show returned metadata
   --dry                            Return serialized transaction without sending it
   --fee=fee                        Fee in Luna (default: 0)
   --staker-wallet=staker-wallet    Address of unlocked staker account (default: WALLET)
@@ -439,7 +409,6 @@ ARGUMENTS
   VALUE   NIM amount to unstake
 
 OPTIONS
-  -m, --show-metadata              Show returned metadata
   --dry                            Return serialized transaction without sending it
   --fee=fee                        Fee in Luna (default: 0)
   --recipient=recipient            Address to receive stake (default: WALLET)
@@ -458,9 +427,6 @@ Show the current status of the node
 ```
 USAGE
   $ arpl status
-
-OPTIONS
-  -m, --show-metadata  Show returned metadata
 ```
 
 _See code: [src/commands/status.ts](https://github.com/sisou/arpl/blob/v0.8.2/src/commands/status.ts)_
@@ -475,9 +441,6 @@ USAGE
 
 ARGUMENTS
   HASH  Transaction hash of the transaction to get
-
-OPTIONS
-  -m, --show-metadata  Show returned metadata
 
 ALIASES
   $ arpl tx:get
@@ -499,7 +462,6 @@ ARGUMENTS
   VALUE      NIM amount to send
 
 OPTIONS
-  -m, --show-metadata              Show returned metadata
   --data=data                      HEX-encoded data
   --dry                            Return serialized transaction without sending it
   --fee=fee                        Fee in Luna (default: 0)
@@ -523,7 +485,6 @@ ARGUMENTS
   WALLET  Address of unlocked account that owns the validator
 
 OPTIONS
-  -m, --show-metadata              Show returned metadata
   --dry                            Return serialized transaction without sending it
   --fee=fee                        Fee in Luna (default: 0)
   --recipient=recipient            Address to receive validator deposit (default: sender address)
@@ -544,9 +505,8 @@ ARGUMENTS
   VALIDATOR_ADDRESS  Address of validator to show information for
 
 OPTIONS
-  -m, --show-metadata  Show returned metadata
-  --plain              Display plain command output
-  --stakers            Include a list of the validator's stakers
+  --plain    Display plain command output
+  --stakers  Include a list of the validator's stakers
 ```
 
 _See code: [src/commands/validator/get.ts](https://github.com/sisou/arpl/blob/v0.8.2/src/commands/validator/get.ts)_
@@ -565,7 +525,6 @@ ARGUMENTS
   SIGNING_SECRET_KEY  Secret key used to sign the reactivate transaction
 
 OPTIONS
-  -m, --show-metadata              Show returned metadata
   --dry                            Return serialized transaction without sending it
   --fee=fee                        Fee in Luna (default: 0)
   --validity-start=validity-start  [default: +0] Validity start height of the transaction
@@ -591,7 +550,6 @@ ARGUMENTS
   VOTING_SECRET_KEY   BLS secret key used when signing votes (for Macro blocks and view changes)
 
 OPTIONS
-  -m, --show-metadata                    Show returned metadata
   --dry                                  Return serialized transaction without sending it
   --fee=fee                              Fee in Luna (default: 0)
   --reward-address=reward-address        Reward address for the validator (default: sending address)
@@ -619,7 +577,6 @@ ARGUMENTS
   SIGNING_SECRET_KEY  Secret key used to sign the reactivate transaction
 
 OPTIONS
-  -m, --show-metadata              Show returned metadata
   --dry                            Return serialized transaction without sending it
   --fee=fee                        Fee in Luna (default: 0)
   --validity-start=validity-start  [default: +0] Validity start height of the transaction
@@ -641,7 +598,6 @@ ARGUMENTS
   SIGNING_SECRET_KEY  Secret key used to sign the unpark transaction
 
 OPTIONS
-  -m, --show-metadata              Show returned metadata
   --dry                            Return serialized transaction without sending it
   --fee=fee                        Fee in Luna (default: 0)
   --validity-start=validity-start  [default: +0] Validity start height of the transaction
@@ -662,7 +618,6 @@ ARGUMENTS
   VALIDATOR_ADDRESS  Address of unlocked account that owns the validator
 
 OPTIONS
-  -m, --show-metadata                      Show returned metadata
   --dry                                    Return serialized transaction without sending it
   --fee=fee                                Fee in Luna (default: 0)
   --reward-address=reward-address          New reward address for the validator (default: no change)

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ USAGE
   $ arpl account:create
 
 OPTIONS
+  -m, --show-metadata  Show returned metadata
   --password=password  Password to encrypt the key
   --unlock             Unlock the account after creation
 ```
@@ -101,6 +102,9 @@ USAGE
 
 ARGUMENTS
   ADDRESS  Address of the account to follow
+
+OPTIONS
+  -m, --show-metadata  Show returned metadata
 ```
 
 _See code: [src/commands/account/follow.ts](https://github.com/sisou/arpl/blob/v0.8.2/src/commands/account/follow.ts)_
@@ -115,6 +119,9 @@ USAGE
 
 ARGUMENTS
   ADDRESS  Address of the account to display
+
+OPTIONS
+  -m, --show-metadata  Show returned metadata
 ```
 
 _See code: [src/commands/account/get.ts](https://github.com/sisou/arpl/blob/v0.8.2/src/commands/account/get.ts)_
@@ -131,6 +138,7 @@ ARGUMENTS
   PRIVATEKEY  Private key in HEX or Base64 format
 
 OPTIONS
+  -m, --show-metadata  Show returned metadata
   --password=password  Password to encrypt the key
   --unlock             Unlock the account after import
 ```
@@ -144,6 +152,9 @@ List accounts available in node
 ```
 USAGE
   $ arpl account:list
+
+OPTIONS
+  -m, --show-metadata  Show returned metadata
 ```
 
 _See code: [src/commands/account/list.ts](https://github.com/sisou/arpl/blob/v0.8.2/src/commands/account/list.ts)_
@@ -158,6 +169,9 @@ USAGE
 
 ARGUMENTS
   ADDRESS  Address of the account to lock
+
+OPTIONS
+  -m, --show-metadata  Show returned metadata
 ```
 
 _See code: [src/commands/account/lock.ts](https://github.com/sisou/arpl/blob/v0.8.2/src/commands/account/lock.ts)_
@@ -174,6 +188,7 @@ ARGUMENTS
   ADDRESS  Address to display transactions for
 
 OPTIONS
+  -m, --show-metadata     Show returned metadata
   -x, --extended          show extra columns
   --columns=columns       only show provided columns (comma-separated)
   --csv                   output is csv format [alias: --output=csv]
@@ -202,6 +217,7 @@ ARGUMENTS
   ADDRESS  Address of the account to unlock
 
 OPTIONS
+  -m, --show-metadata  Show returned metadata
   --password=password  Password to decrypt the key
 ```
 
@@ -214,6 +230,9 @@ Stream blocks live
 ```
 USAGE
   $ arpl block:follow
+
+OPTIONS
+  -m, --show-metadata  Show returned metadata
 ```
 
 _See code: [src/commands/block/follow.ts](https://github.com/sisou/arpl/blob/v0.8.2/src/commands/block/follow.ts)_
@@ -230,7 +249,8 @@ ARGUMENTS
   NUMBER_OR_HASH  [default: latest] Block number or hash of the block to get
 
 OPTIONS
-  --full  Include block body (transactions, etc.)
+  -m, --show-metadata  Show returned metadata
+  --full               Include block body (transactions, etc.)
 ```
 
 _See code: [src/commands/block/get.ts](https://github.com/sisou/arpl/blob/v0.8.2/src/commands/block/get.ts)_
@@ -259,6 +279,9 @@ Get the local peer ID of the node
 ```
 USAGE
   $ arpl peer:id
+
+OPTIONS
+  -m, --show-metadata  Show returned metadata
 ```
 
 _See code: [src/commands/peer/id.ts](https://github.com/sisou/arpl/blob/v0.8.2/src/commands/peer/id.ts)_
@@ -270,6 +293,9 @@ Run a raw Nimiq JSON-RPC command
 ```
 USAGE
   $ arpl raw COMMAND [OPTIONS]
+
+OPTIONS
+  -m, --show-metadata  Show returned metadata
 ```
 
 _See code: [src/commands/raw.ts](https://github.com/sisou/arpl/blob/v0.8.2/src/commands/raw.ts)_
@@ -301,6 +327,7 @@ ARGUMENTS
   VALUE   NIM amount to add
 
 OPTIONS
+  -m, --show-metadata              Show returned metadata
   --address=address                Staker address to add stake to (default: sender address)
   --dry                            Return serialized transaction without sending it
   --fee=fee                        Fee in Luna (default: 0)
@@ -324,7 +351,8 @@ ARGUMENTS
   STAKER_ADDRESS  Address of staker to show information for
 
 OPTIONS
-  --plain  Display plain command output
+  -m, --show-metadata  Show returned metadata
+  --plain              Display plain command output
 
 ALIASES
   $ arpl staker:get
@@ -341,7 +369,8 @@ USAGE
   $ arpl stake:list
 
 OPTIONS
-  --plain  Display plain command output
+  -m, --show-metadata  Show returned metadata
+  --plain              Display plain command output
 ```
 
 _See code: [src/commands/stake/list.ts](https://github.com/sisou/arpl/blob/v0.8.2/src/commands/stake/list.ts)_
@@ -359,6 +388,7 @@ ARGUMENTS
   NEW_VALIDATOR_ADDRESS  Address of the validator to move stake to
 
 OPTIONS
+  -m, --show-metadata              Show returned metadata
   --dry                            Return serialized transaction without sending it
   --fee=fee                        Fee in Luna (default: 0)
   --fee-wallet=fee-wallet          Address of unlocked account to pay the fee from (default: fee is paid from stake)
@@ -384,6 +414,7 @@ ARGUMENTS
   VALUE              NIM amount to stake
 
 OPTIONS
+  -m, --show-metadata              Show returned metadata
   --dry                            Return serialized transaction without sending it
   --fee=fee                        Fee in Luna (default: 0)
   --staker-wallet=staker-wallet    Address of unlocked staker account (default: WALLET)
@@ -408,6 +439,7 @@ ARGUMENTS
   VALUE   NIM amount to unstake
 
 OPTIONS
+  -m, --show-metadata              Show returned metadata
   --dry                            Return serialized transaction without sending it
   --fee=fee                        Fee in Luna (default: 0)
   --recipient=recipient            Address to receive stake (default: WALLET)
@@ -426,6 +458,9 @@ Show the current status of the node
 ```
 USAGE
   $ arpl status
+
+OPTIONS
+  -m, --show-metadata  Show returned metadata
 ```
 
 _See code: [src/commands/status.ts](https://github.com/sisou/arpl/blob/v0.8.2/src/commands/status.ts)_
@@ -440,6 +475,9 @@ USAGE
 
 ARGUMENTS
   HASH  Transaction hash of the transaction to get
+
+OPTIONS
+  -m, --show-metadata  Show returned metadata
 
 ALIASES
   $ arpl tx:get
@@ -461,6 +499,7 @@ ARGUMENTS
   VALUE      NIM amount to send
 
 OPTIONS
+  -m, --show-metadata              Show returned metadata
   --data=data                      HEX-encoded data
   --dry                            Return serialized transaction without sending it
   --fee=fee                        Fee in Luna (default: 0)
@@ -484,6 +523,7 @@ ARGUMENTS
   WALLET  Address of unlocked account that owns the validator
 
 OPTIONS
+  -m, --show-metadata              Show returned metadata
   --dry                            Return serialized transaction without sending it
   --fee=fee                        Fee in Luna (default: 0)
   --recipient=recipient            Address to receive validator deposit (default: sender address)
@@ -504,8 +544,9 @@ ARGUMENTS
   VALIDATOR_ADDRESS  Address of validator to show information for
 
 OPTIONS
-  --plain    Display plain command output
-  --stakers  Include a list of the validator's stakers
+  -m, --show-metadata  Show returned metadata
+  --plain              Display plain command output
+  --stakers            Include a list of the validator's stakers
 ```
 
 _See code: [src/commands/validator/get.ts](https://github.com/sisou/arpl/blob/v0.8.2/src/commands/validator/get.ts)_
@@ -524,6 +565,7 @@ ARGUMENTS
   SIGNING_SECRET_KEY  Secret key used to sign the reactivate transaction
 
 OPTIONS
+  -m, --show-metadata              Show returned metadata
   --dry                            Return serialized transaction without sending it
   --fee=fee                        Fee in Luna (default: 0)
   --validity-start=validity-start  [default: +0] Validity start height of the transaction
@@ -549,6 +591,7 @@ ARGUMENTS
   VOTING_SECRET_KEY   BLS secret key used when signing votes (for Macro blocks and view changes)
 
 OPTIONS
+  -m, --show-metadata                    Show returned metadata
   --dry                                  Return serialized transaction without sending it
   --fee=fee                              Fee in Luna (default: 0)
   --reward-address=reward-address        Reward address for the validator (default: sending address)
@@ -576,6 +619,7 @@ ARGUMENTS
   SIGNING_SECRET_KEY  Secret key used to sign the reactivate transaction
 
 OPTIONS
+  -m, --show-metadata              Show returned metadata
   --dry                            Return serialized transaction without sending it
   --fee=fee                        Fee in Luna (default: 0)
   --validity-start=validity-start  [default: +0] Validity start height of the transaction
@@ -597,6 +641,7 @@ ARGUMENTS
   SIGNING_SECRET_KEY  Secret key used to sign the unpark transaction
 
 OPTIONS
+  -m, --show-metadata              Show returned metadata
   --dry                            Return serialized transaction without sending it
   --fee=fee                        Fee in Luna (default: 0)
   --validity-start=validity-start  [default: +0] Validity start height of the transaction
@@ -617,6 +662,7 @@ ARGUMENTS
   VALIDATOR_ADDRESS  Address of unlocked account that owns the validator
 
 OPTIONS
+  -m, --show-metadata                      Show returned metadata
   --dry                                    Return serialized transaction without sending it
   --fee=fee                                Fee in Luna (default: 0)
   --reward-address=reward-address          New reward address for the validator (default: no change)

--- a/src/commands/account/follow.ts
+++ b/src/commands/account/follow.ts
@@ -13,10 +13,16 @@ export default class AccountFollow extends RpcCommand {
   }]
 
   async run() {
-    const {args} = this.parse(AccountFollow)
+    const {args, flags} = this.parse(AccountFollow)
 
-    const subscriptionId = await this.call(AccountFollow, 'subscribeForLogsByAddressesAndTypes', [[args.address], []]) as number // Throws when not in REPL
-    this.log('Subscribed to account events');
+    // Throws when not in REPL
+    const {data: subscriptionId, metadata} = await this.call<number>(
+      AccountFollow,
+      'subscribeForLogsByAddressesAndTypes',
+      [[args.address], []],
+    )
+    this.log('Subscribed to account events')
+    this.showMetadataIfRequested(metadata, flags);
 
     (this.$rpc as Socket).on('subscribeForLogsByAddressesAndTypes', async ({result: blockLog, subscription}: { result: AppliedBlockLog | RevertedBlockLog; subscription: number }) => {
       if (subscription !== subscriptionId) return

--- a/src/commands/account/follow.ts
+++ b/src/commands/account/follow.ts
@@ -24,10 +24,13 @@ export default class AccountFollow extends RpcCommand {
     this.log('Subscribed to account events')
     this.showMetadataIfRequested(metadata, flags);
 
-    (this.$rpc as Socket).on('subscribeForLogsByAddressesAndTypes', async ({result: blockLog, subscription}: { result: AppliedBlockLog | RevertedBlockLog; subscription: number }) => {
-      if (subscription !== subscriptionId) return
-
-      console.dir(blockLog, {depth: Infinity}) // eslint-disable-line no-console
-    })
+    (this.$rpc as Socket).onSubscription<AppliedBlockLog | RevertedBlockLog>(
+      'subscribeForLogsByAddressesAndTypes',
+      subscriptionId,
+      ({data: blockLog, metadata}) => {
+        console.dir(blockLog, {depth: Infinity}) // eslint-disable-line no-console
+        this.showMetadataIfRequested(metadata, flags, 'Account subscription')
+      },
+    )
   }
 }

--- a/src/commands/account/get.ts
+++ b/src/commands/account/get.ts
@@ -16,14 +16,15 @@ export default class AccountGet extends RpcCommand {
   }
 
   async run() {
-    const {args} = this.parse(AccountGet)
+    const {args, flags} = this.parse(AccountGet)
 
-    const account = await this.call(AccountGet, 'getAccountByAddress', [args.address]) as Account
+    const {data: account, metadata} = await this.call<Account>(AccountGet, 'getAccountByAddress', [args.address])
 
     this.log(`Type: ${account.type}`)
     this.log(`Balance: ${formatBalance(account.balance)}`)
     if (account.type !== 'basic') {
       console.dir(account, {depth: Infinity, maxArrayLength: Infinity}) // eslint-disable-line no-console
     }
+    this.showMetadataIfRequested(metadata, flags)
   }
 }

--- a/src/commands/account/import.ts
+++ b/src/commands/account/import.ts
@@ -24,13 +24,26 @@ export default class AccountImport extends RpcCommand {
   async run() {
     const {args, flags} = this.parse(AccountImport)
 
-    const address = await this.call(AccountImport, 'importRawKey', [args.privatekey, flags.password || null])
+    const {data: address, metadata: importMetadata} = await this.call(
+      AccountImport,
+      'importRawKey',
+      [args.privatekey, flags.password || null],
+    )
 
+    let unlockMetadata
     if (flags.unlock) {
-      this.log('Key imported, unlocking...')
-      await this.call(AccountImport, 'unlockAccount', [address, flags.password || null, /* duration */ null])
+      this.log('Key imported, unlocking...');
+      ({metadata: unlockMetadata} = await this.call(
+        AccountImport,
+        'unlockAccount',
+        [address, flags.password || null, /* duration */ null],
+      ))
     }
 
     this.log(`Account imported: ${address} (${flags.unlock ? 'unlocked' : 'locked'})`)
+    this.showMetadataIfRequested(importMetadata, flags, flags.unlock ? 'Import' : undefined)
+    if (flags.unlock) {
+      this.showMetadataIfRequested(unlockMetadata, flags, 'Unlock')
+    }
   }
 }

--- a/src/commands/account/list.ts
+++ b/src/commands/account/list.ts
@@ -4,9 +4,11 @@ export default class AccountList extends RpcCommand {
   static description = 'List accounts available in node'
 
   async run() {
-    const accounts = await this.call(AccountList, 'listAccounts')
+    const {flags} = this.parse(AccountList)
+    const {data: accounts, metadata} = await this.call(AccountList, 'listAccounts')
 
     // TODO: Display accounts nicely
     console.dir(accounts, {depth: Infinity, maxArrayLength: Infinity}) // eslint-disable-line no-console
+    this.showMetadataIfRequested(metadata, flags)
   }
 }

--- a/src/commands/account/lock.ts
+++ b/src/commands/account/lock.ts
@@ -14,10 +14,11 @@ export default class AccountLock extends RpcCommand {
   }
 
   async run() {
-    const {args} = this.parse(AccountLock)
+    const {args, flags} = this.parse(AccountLock)
 
-    await this.call(AccountLock, 'lockAccount', [args.address])
+    const {metadata} = await this.call(AccountLock, 'lockAccount', [args.address])
 
     this.log(`Account locked: ${args.address}`)
+    this.showMetadataIfRequested(metadata, flags)
   }
 }

--- a/src/commands/account/transactions.ts
+++ b/src/commands/account/transactions.ts
@@ -30,9 +30,13 @@ export default class AccountTransactions extends RpcCommand {
   async run() {
     const {args, flags} = this.parse(AccountTransactions)
 
-    const result = await this.call(AccountTransactions, 'getTransactionsByAddress', [args.address, flags.max || null]) as Transaction[]
+    const {data: transactions, metadata} = await this.call<Transaction[]>(
+      AccountTransactions,
+      'getTransactionsByAddress',
+      [args.address, flags.max || null],
+    )
 
-    cli.table(result, {
+    cli.table(transactions, {
       blockNumber: {
         header: 'Block',
         extended: true,
@@ -69,5 +73,7 @@ export default class AccountTransactions extends RpcCommand {
         // TODO: Try to decode data into UTF8 message
       },
     }, {...flags})
+
+    this.showMetadataIfRequested(metadata, flags)
   }
 }

--- a/src/commands/account/unlock.ts
+++ b/src/commands/account/unlock.ts
@@ -21,8 +21,13 @@ export default class AccountUnlock extends RpcCommand {
   async run() {
     const {args, flags} = this.parse(AccountUnlock)
 
-    await this.call(AccountUnlock, 'unlockAccount', [args.address, flags.password || null, /* duration */ null])
+    const {metadata} = await this.call(
+      AccountUnlock,
+      'unlockAccount',
+      [args.address, flags.password || null, /* duration */ null],
+    )
 
     this.log(`Account unlocked: ${args.address}`)
+    this.showMetadataIfRequested(metadata, flags)
   }
 }

--- a/src/commands/block/follow.ts
+++ b/src/commands/block/follow.ts
@@ -14,9 +14,7 @@ export default class BlockFollow extends RpcCommand {
     this.log('Subscribed to blocks')
     this.showMetadataIfRequested(metadata, flags);
 
-    (this.$rpc as Socket).on('subscribeForHeadBlock', async ({result: block, subscription}: {result: Block; subscription: number}) => {
-      if (subscription !== subscriptionId) return
-
+    (this.$rpc as Socket).onSubscription<Block>('subscribeForHeadBlock', subscriptionId, ({data: block, metadata}) => {
       const batchesPerEpoch = Math.ceil(block.batch / block.epoch)
 
       this.log([
@@ -32,6 +30,8 @@ export default class BlockFollow extends RpcCommand {
             `election (epoch ${block.epoch} => ${block.epoch + 1})` :
             `checkpoint (batch ${block.batch % batchesPerEpoch}/${batchesPerEpoch})`,
       ].join(' ｜'))
+
+      this.showMetadataIfRequested(metadata, flags, 'Block subscription')
     })
   }
 }

--- a/src/commands/block/follow.ts
+++ b/src/commands/block/follow.ts
@@ -7,8 +7,12 @@ export default class BlockFollow extends RpcCommand {
   static description = 'Stream blocks live'
 
   async run() {
-    const subscriptionId = await this.call(BlockFollow, 'subscribeForHeadBlock', [true]) as number // Throws when not in REPL
-    this.log('Subscribed to blocks');
+    const {flags} = this.parse(BlockFollow)
+
+    // Throws when not in REPL
+    const {data: subscriptionId, metadata} = await this.call<number>(BlockFollow, 'subscribeForHeadBlock', [true])
+    this.log('Subscribed to blocks')
+    this.showMetadataIfRequested(metadata, flags);
 
     (this.$rpc as Socket).on('subscribeForHeadBlock', async ({result: block, subscription}: {result: Block; subscription: number}) => {
       if (subscription !== subscriptionId) return

--- a/src/commands/block/get.ts
+++ b/src/commands/block/get.ts
@@ -37,8 +37,9 @@ export default class BlockGet extends RpcCommand {
       ]
     }
 
-    const result = await this.call(BlockGet, method, params)
+    const {data: block, metadata} = await this.call(BlockGet, method, params)
 
-    console.dir(result, {depth: Infinity, maxArrayLength: Infinity}) // eslint-disable-line no-console
+    console.dir(block, {depth: Infinity, maxArrayLength: Infinity}) // eslint-disable-line no-console
+    this.showMetadataIfRequested(metadata, flags)
   }
 }

--- a/src/commands/peer/id.ts
+++ b/src/commands/peer/id.ts
@@ -4,8 +4,11 @@ export default class PeerId extends RpcCommand {
   static description = 'Get the local peer ID of the node'
 
   async run() {
-    const peerId = await this.call(PeerId, 'getPeerId') as string
+    const {flags} = this.parse(PeerId)
+
+    const {data: peerId, metadata} = await this.call<string>(PeerId, 'getPeerId')
 
     this.log(`Peer ID: ${peerId}`)
+    this.showMetadataIfRequested(metadata, flags)
   }
 }

--- a/src/commands/raw.ts
+++ b/src/commands/raw.ts
@@ -14,6 +14,8 @@ export default class Raw extends RpcCommand {
   static strict = false
 
   async run() {
+    const {flags} = this.parse(Raw)
+
     const [id, ...argv] = this.argv.filter((arg, i, arr) => {
       const isFlag = arg.startsWith('-')
       const isFlagArgument = i > 0 ? arr[i - 1].startsWith('-') && !arr[i - 1].includes('=') : false
@@ -39,8 +41,9 @@ export default class Raw extends RpcCommand {
       return arg
     })
 
-    const result = await this.call(Raw, id, params)
+    const {data, metadata} = await this.call<unknown>(Raw, id, params)
 
-    console.dir(result, {depth: Infinity, maxArrayLength: Infinity}) // eslint-disable-line no-console
+    console.dir(data, {depth: Infinity, maxArrayLength: Infinity}) // eslint-disable-line no-console
+    this.showMetadataIfRequested(metadata, flags)
   }
 }

--- a/src/commands/stake/add.ts
+++ b/src/commands/stake/add.ts
@@ -28,7 +28,8 @@ export default class StakeAdd extends RpcCommand {
   async run() {
     const {args, flags} = this.parse(StakeAdd)
 
-    const hash = await this.call(StakeAdd, `${flags.dry ? 'create' : 'send'}StakeTransaction`, [
+    const method = `${flags.dry ? 'create' : 'send'}StakeTransaction`
+    const {data: hash, metadata} = await this.call(StakeAdd, method, [
       args.wallet,
       flags.address || args.wallet,
       args.value,
@@ -37,5 +38,6 @@ export default class StakeAdd extends RpcCommand {
     ])
 
     this.log(`Transaction ${flags.dry ? 'prepared' : 'sent'}: ${hash}`)
+    this.showMetadataIfRequested(metadata, flags)
   }
 }

--- a/src/commands/stake/get.ts
+++ b/src/commands/stake/get.ts
@@ -23,15 +23,18 @@ export default class StakeGet extends RpcCommand {
   }
 
   async run() {
-    const {args} = this.parse(StakeGet)
+    const {args, flags} = this.parse(StakeGet)
 
-    const staker = await this.call(StakeGet, 'getStakerByAddress', [
-      args.staker_address,
-    ]) as BlockchainState<Staker>
+    const {data: staker, metadata} = await this.call<BlockchainState<Staker>>(
+      StakeGet,
+      'getStakerByAddress',
+      [args.staker_address],
+    )
 
     // if (flags.plain) {
     console.dir(staker, {depth: Infinity, maxArrayLength: Infinity}) // eslint-disable-line no-console
     //   return
     // }
+    this.showMetadataIfRequested(metadata, flags)
   }
 }

--- a/src/commands/stake/list.ts
+++ b/src/commands/stake/list.ts
@@ -16,9 +16,9 @@ export default class StakeList extends RpcCommand {
   }
 
   async run() {
-    // const {flags} = this.parse(StakeList)
+    const {flags} = this.parse(StakeList)
 
-    const stakes = await this.call(StakeList, 'getActiveValidators') as Validator[]
+    const {data: stakes, metadata} = await this.call<Validator[]>(StakeList, 'getActiveValidators')
 
     // if (flags.plain) {
     console.dir(stakes, {depth: Infinity, maxArrayLength: Infinity}) // eslint-disable-line no-console
@@ -64,5 +64,7 @@ export default class StakeList extends RpcCommand {
     //   this.log(`${stake.staker_address} | ${formatBalance(stake.balance)}`)
     // }
     // if (stakes.inactiveStakes.length === 0) this.log('-none-')
+
+    this.showMetadataIfRequested(metadata, flags)
   }
 }

--- a/src/commands/stake/move.ts
+++ b/src/commands/stake/move.ts
@@ -31,7 +31,7 @@ export default class StakeMove extends RpcCommand {
       pay_fee_from_stake = await this.canPayFeeFromStake(args.wallet, flags)
     }
 
-    const hash = await this.call(StakeMove, `${flags.dry ? 'create' : 'send'}UpdateTransaction`, [
+    const hash = await this.call(StakeMove, `${flags.dry ? 'create' : 'send'}UpdateStakerTransaction`, [
       pay_fee_from_stake ? null : flags['fee-wallet'],
       args.wallet,
       args.new_validator_address,

--- a/src/commands/stake/move.ts
+++ b/src/commands/stake/move.ts
@@ -31,7 +31,8 @@ export default class StakeMove extends RpcCommand {
       pay_fee_from_stake = await this.canPayFeeFromStake(args.wallet, flags)
     }
 
-    const hash = await this.call(StakeMove, `${flags.dry ? 'create' : 'send'}UpdateStakerTransaction`, [
+    const method = `${flags.dry ? 'create' : 'send'}UpdateStakerTransaction`
+    const {data: hash, metadata} = await this.call(StakeMove, method, [
       pay_fee_from_stake ? null : flags['fee-wallet'],
       args.wallet,
       args.new_validator_address,
@@ -40,5 +41,6 @@ export default class StakeMove extends RpcCommand {
     ])
 
     this.log(`Transaction ${flags.dry ? 'prepared' : 'sent'}: ${hash}`)
+    this.showMetadataIfRequested(metadata, flags)
   }
 }

--- a/src/commands/stake/start.ts
+++ b/src/commands/stake/start.ts
@@ -32,7 +32,8 @@ export default class StakeStart extends RpcCommand {
   async run() {
     const {args, flags} = this.parse(StakeStart)
 
-    const hash = await this.call(StakeStart, `${flags.dry ? 'create' : 'send'}NewStakerTransaction`, [
+    const method = `${flags.dry ? 'create' : 'send'}NewStakerTransaction`
+    const {data: hash, metadata} = await this.call(StakeStart, method, [
       args.wallet,
       flags['staker-wallet'] || args.wallet,
       args.validator_address,
@@ -42,5 +43,6 @@ export default class StakeStart extends RpcCommand {
     ])
 
     this.log(`Transaction ${flags.dry ? 'prepared' : 'sent'}: ${hash}`)
+    this.showMetadataIfRequested(metadata, flags)
   }
 }

--- a/src/commands/stake/stop.ts
+++ b/src/commands/stake/stop.ts
@@ -29,7 +29,8 @@ export default class StakeStop extends RpcCommand {
   async run() {
     const {args, flags} = this.parse(StakeStop)
 
-    const hash = await this.call(StakeStop, `${flags.dry ? 'create' : 'send'}UnstakeTransaction`, [
+    const method = `${flags.dry ? 'create' : 'send'}UnstakeTransaction`
+    const {data: hash, metadata} = await this.call(StakeStop, method, [
       args.wallet,
       flags.recipient || args.wallet,
       args.value,
@@ -38,5 +39,6 @@ export default class StakeStop extends RpcCommand {
     ])
 
     this.log(`Transaction ${flags.dry ? 'prepared' : 'sent'}: ${hash}`)
+    this.showMetadataIfRequested(metadata, flags)
   }
 }

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -19,7 +19,7 @@ export default class Status extends RpcCommand {
       // TODO: Get validator status
     ])
 
-    const showMetadata = flags['show-metadata']
+    const showMetadata = flags.metadata
     const metadataTemplate = showMetadata ? chalk.dim(' - Metadata: %O') : ''
     this.log(
       `Consensus: %s${metadataTemplate}`,

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -5,22 +5,29 @@ export default class Status extends RpcCommand {
   static description = 'Show the current status of the node'
 
   async run() {
+    const {flags} = this.parse(Status)
     const [
-      blockNumber,
-      epochNumber,
-      established,
-      peerCount,
+      {data: established, metadata: establishedMetadata},
+      {data: blockNumber, metadata: blockNumberMetadata},
+      {data: epochNumber, metadata: epochNumberMetadata},
+      {data: peerCount, metadata: peerCountMetadata},
     ] = await Promise.all([
-      this.call(Status, 'getBlockNumber') as Promise<number>,
-      this.call(Status, 'getEpochNumber') as Promise<number>,
-      this.call(Status, 'isConsensusEstablished') as Promise<boolean>,
-      this.call(Status, 'getPeerCount') as Promise<number>,
+      this.call<boolean>(Status, 'isConsensusEstablished'),
+      this.call<number>(Status, 'getBlockNumber'),
+      this.call<number>(Status, 'getEpochNumber'),
+      this.call<number>(Status, 'getPeerCount'),
       // TODO: Get validator status
     ])
 
-    this.log('Consensus:', established ? chalk.green('established') : chalk.yellow('syncing'))
-    this.log('Height:', blockNumber)
-    this.log('Epoch:', epochNumber)
-    this.log('Peers:', peerCount)
+    const showMetadata = flags['show-metadata']
+    const metadataTemplate = showMetadata ? chalk.dim(' - Metadata: %O') : ''
+    this.log(
+      `Consensus: %s${metadataTemplate}`,
+      established ? chalk.green('established') : chalk.yellow('syncing'),
+      showMetadata ? establishedMetadata : '',
+    )
+    this.log(`Height: %d${metadataTemplate}`, blockNumber, showMetadata ? blockNumberMetadata : '')
+    this.log(`Epoch: %d${metadataTemplate}`, epochNumber, showMetadata ? epochNumberMetadata : '')
+    this.log(`Peers: %d${metadataTemplate}`, peerCount, showMetadata ? peerCountMetadata : '')
   }
 }

--- a/src/commands/transaction/get.ts
+++ b/src/commands/transaction/get.ts
@@ -1,4 +1,5 @@
 import {RpcCommand} from '../../lib/rpc-command'
+import {Transaction} from '../../lib/server-types'
 
 export default class TransactionGet extends RpcCommand {
   static description = 'Show transaction information'
@@ -12,10 +13,15 @@ export default class TransactionGet extends RpcCommand {
   }]
 
   async run() {
-    const {args} = this.parse(TransactionGet)
+    const {args, flags} = this.parse(TransactionGet)
 
-    const result = await this.call(TransactionGet, 'getTransactionByHash', [args.hash])
+    const {data: transaction, metadata} = await this.call<Transaction>(
+      TransactionGet,
+      'getTransactionByHash',
+      [args.hash],
+    )
 
-    console.dir(result, {depth: Infinity, maxArrayLength: Infinity}) // eslint-disable-line no-console
+    console.dir(transaction, {depth: Infinity, maxArrayLength: Infinity}) // eslint-disable-line no-console
+    this.showMetadataIfRequested(metadata, flags)
   }
 }

--- a/src/commands/transaction/send.ts
+++ b/src/commands/transaction/send.ts
@@ -33,7 +33,7 @@ export default class TransactionSend extends RpcCommand {
     const {args, flags} = this.parse(TransactionSend)
 
     const method = `${flags.dry ? 'create' : 'send'}BasicTransaction${flags.data ? 'WithData' : ''}`
-    const hash = await this.call(TransactionSend, method, [
+    const {data: hash, metadata} = await this.call(TransactionSend, method, [
       args.wallet,
       args.recipient,
       ...(flags.data ? [flags.data] : []),
@@ -43,5 +43,6 @@ export default class TransactionSend extends RpcCommand {
     ])
 
     this.log(`Transaction ${flags.dry ? 'prepared' : 'sent'}: ${hash}`)
+    this.showMetadataIfRequested(metadata, flags)
   }
 }

--- a/src/commands/validator/delete.ts
+++ b/src/commands/validator/delete.ts
@@ -21,7 +21,8 @@ export default class ValidatorDelete extends RpcCommand {
   async run() {
     const {args, flags} = this.parse(ValidatorDelete)
 
-    const hash = await this.call(ValidatorDelete, `${flags.dry ? 'create' : 'send'}DeleteValidatorTransaction`, [
+    const method = `${flags.dry ? 'create' : 'send'}DeleteValidatorTransaction`
+    const {data: hash, metadata} = await this.call(ValidatorDelete, method, [
       args.wallet,
       flags.recipient || args.wallet,
       flags.fee,
@@ -29,5 +30,6 @@ export default class ValidatorDelete extends RpcCommand {
     ])
 
     this.log(`Transaction ${flags.dry ? 'prepared' : 'sent'}: ${hash}`)
+    this.showMetadataIfRequested(metadata, flags)
   }
 }

--- a/src/commands/validator/get.ts
+++ b/src/commands/validator/get.ts
@@ -27,14 +27,16 @@ export default class ValidatorGet extends RpcCommand {
   async run() {
     const {args, flags} = this.parse(ValidatorGet)
 
-    const validator = await this.call(ValidatorGet, 'getValidatorByAddress', [
-      args.validator_address,
-      flags.stakers,
-    ]) as BlockchainState<Validator>
+    const {data: validator, metadata} = await this.call<BlockchainState<Validator>>(
+      ValidatorGet,
+      'getValidatorByAddress',
+      [args.validator_address, flags.stakers],
+    )
 
     // if (flags.plain) {
     console.dir(validator, {depth: Infinity, maxArrayLength: Infinity}) // eslint-disable-line no-console
     //   return
     // }
+    this.showMetadataIfRequested(metadata, flags)
   }
 }

--- a/src/commands/validator/inactivate.ts
+++ b/src/commands/validator/inactivate.ts
@@ -25,7 +25,8 @@ export default class ValidatorInactivate extends RpcCommand {
   async run() {
     const {args, flags} = this.parse(ValidatorInactivate)
 
-    const hash = await this.call(ValidatorInactivate, `${flags.dry ? 'create' : 'send'}InactivateValidatorTransaction`, [
+    const method = `${flags.dry ? 'create' : 'send'}InactivateValidatorTransaction`
+    const {data: hash, metadata} = await this.call(ValidatorInactivate, method, [
       args.wallet,
       args.validator_address,
       args.signing_secret_key,
@@ -34,5 +35,6 @@ export default class ValidatorInactivate extends RpcCommand {
     ])
 
     this.log(`Transaction ${flags.dry ? 'prepared' : 'sent'}: ${hash}`)
+    this.showMetadataIfRequested(metadata, flags)
   }
 }

--- a/src/commands/validator/new.ts
+++ b/src/commands/validator/new.ts
@@ -36,7 +36,8 @@ export default class ValidatorNew extends RpcCommand {
   async run() {
     const {args, flags} = this.parse(ValidatorNew)
 
-    const hash = await this.call(ValidatorNew, `${flags.dry ? 'create' : 'send'}NewValidatorTransaction`, [
+    const method = `${flags.dry ? 'create' : 'send'}NewValidatorTransaction`
+    const {data: hash, metadata} = await this.call(ValidatorNew, method, [
       args.wallet,
       flags['validator-address'] || args.wallet,
       args.signing_secret_key,
@@ -48,5 +49,6 @@ export default class ValidatorNew extends RpcCommand {
     ])
 
     this.log(`Transaction ${flags.dry ? 'prepared' : 'sent'}: ${hash}`)
+    this.showMetadataIfRequested(metadata, flags)
   }
 }

--- a/src/commands/validator/reactivate.ts
+++ b/src/commands/validator/reactivate.ts
@@ -25,7 +25,8 @@ export default class ValidatorReactivate extends RpcCommand {
   async run() {
     const {args, flags} = this.parse(ValidatorReactivate)
 
-    const hash = await this.call(ValidatorReactivate, `${flags.dry ? 'create' : 'send'}ReactivateValidatorTransaction`, [
+    const method = `${flags.dry ? 'create' : 'send'}ReactivateValidatorTransaction`
+    const {data: hash, metadata} = await this.call(ValidatorReactivate, method, [
       args.wallet,
       args.validator_address,
       args.signing_secret_key,
@@ -34,5 +35,6 @@ export default class ValidatorReactivate extends RpcCommand {
     ])
 
     this.log(`Transaction ${flags.dry ? 'prepared' : 'sent'}: ${hash}`)
+    this.showMetadataIfRequested(metadata, flags)
   }
 }

--- a/src/commands/validator/unpark.ts
+++ b/src/commands/validator/unpark.ts
@@ -25,7 +25,8 @@ export default class ValidatorUnpark extends RpcCommand {
   async run() {
     const {args, flags} = this.parse(ValidatorUnpark)
 
-    const hash = await this.call(ValidatorUnpark, `${flags.dry ? 'create' : 'send'}UnparkValidatorTransaction`, [
+    const method = `${flags.dry ? 'create' : 'send'}UnparkValidatorTransaction`
+    const {data: hash, metadata} = await this.call(ValidatorUnpark, method, [
       args.wallet,
       args.validator_address,
       args.signing_secret_key,
@@ -34,5 +35,6 @@ export default class ValidatorUnpark extends RpcCommand {
     ])
 
     this.log(`Transaction ${flags.dry ? 'prepared' : 'sent'}: ${hash}`)
+    this.showMetadataIfRequested(metadata, flags)
   }
 }

--- a/src/commands/validator/update.ts
+++ b/src/commands/validator/update.ts
@@ -34,7 +34,8 @@ export default class ValidatorUpdate extends RpcCommand {
   async run() {
     const {args, flags} = this.parse(ValidatorUpdate)
 
-    const hash = await this.call(ValidatorUpdate, `${flags.dry ? 'create' : 'send'}UpdateValidatorTransaction`, [
+    const method = `${flags.dry ? 'create' : 'send'}UpdateValidatorTransaction`
+    const {data: hash, metadata} = await this.call(ValidatorUpdate, method, [
       args.wallet,
       args.validator_address,
       flags['signing-secret-key'] || null,
@@ -46,5 +47,6 @@ export default class ValidatorUpdate extends RpcCommand {
     ])
 
     this.log(`Transaction ${flags.dry ? 'prepared' : 'sent'}: ${hash}`)
+    this.showMetadataIfRequested(metadata, flags)
   }
 }

--- a/src/help.ts
+++ b/src/help.ts
@@ -18,7 +18,7 @@ export default class MyHelpClass extends Help {
     })
     const requestOptions = renderList([
       ['-t, --timeout', 'Timeout for request in ms, set to 0 to disable (default: 5000)'],
-      ['-m, --show-metadata', 'Show response metadata (default: false)'],
+      ['-m, --metadata', 'Show response metadata (default: false)'],
     ], {
       stripAnsi: this.opts.stripAnsi,
       maxWidth: this.opts.maxWidth - 2,

--- a/src/help.ts
+++ b/src/help.ts
@@ -18,6 +18,7 @@ export default class MyHelpClass extends Help {
     })
     const requestOptions = renderList([
       ['-t, --timeout', 'Timeout for request in ms, set to 0 to disable (default: 5000)'],
+      ['-m, --show-metadata', 'Show response metadata (default: false)'],
     ], {
       stripAnsi: this.opts.stripAnsi,
       maxWidth: this.opts.maxWidth - 2,

--- a/src/lib/rpc-command.ts
+++ b/src/lib/rpc-command.ts
@@ -33,6 +33,7 @@ export abstract class RpcCommand extends Command {
         char: 'm',
         description: 'Show returned metadata',
         default: false,
+        hidden: true,
       }),
     }
 

--- a/src/lib/rpc-command.ts
+++ b/src/lib/rpc-command.ts
@@ -1,5 +1,6 @@
 import {Command, flags} from '@oclif/command'
-import Rpc from './rpc'
+import chalk from 'chalk'
+import Rpc, {RpcResponse} from './rpc'
 import type * as Parser from '@oclif/parser'
 import type {IWSRequestParams} from 'rpc-websockets/dist/lib/client'
 import {Staker} from './server-types'
@@ -27,6 +28,11 @@ export abstract class RpcCommand extends Command {
       auth: flags.string({
         char: 'a',
         hidden: true,
+      }),
+      'show-metadata': flags.boolean({
+        char: 'm',
+        description: 'Show returned metadata',
+        default: false,
       }),
     }
 
@@ -56,15 +62,19 @@ export abstract class RpcCommand extends Command {
     protected parse<F, A extends Record<string, any>>(options: Parser.Input<F>, argv?: string[]): Parser.Output<F, A> {
       const mergedOptions: Parser.Input<any> = {
         ...options,
-        args: options.args || RpcCommand.args,
         flags: options.flags || RpcCommand.flags || {},
       }
       return super.parse(mergedOptions, argv)
     }
 
-    protected call(command: typeof Command, method: string, params?: IWSRequestParams) {
+    protected call<R>(command: typeof Command, method: string, params?: IWSRequestParams): Promise<RpcResponse<R>> {
       const {flags} = this.parse(command)
-      return this.$rpc.call(method, params, flags.timeout)
+      return this.$rpc.call(method, params, flags.timeout) as Promise<RpcResponse<R>>
+    }
+
+    protected showMetadataIfRequested(metadata: any, flags: Parser.flags.Output, description?: string) {
+      if (!flags['show-metadata']) return
+      this.log(chalk.dim(`${description ? `${description} r` : 'R'}esponse metadata: %O`), metadata)
     }
 
     protected async canPayFeeFromStake(
@@ -74,7 +84,7 @@ export abstract class RpcCommand extends Command {
         timeout: number;
       },
     ): Promise<boolean> {
-      const staker = await this.$rpc.call('getStakerByAddress', [stakerAddress], flags.timeout) as Staker
+      const staker = (await this.$rpc.call('getStakerByAddress', [stakerAddress], flags.timeout)).data as Staker
       if (staker.balance > flags.fee) return true
       throw new Error('Cannot pay fee from stake: not enough stake. Use --fee-wallet to specify which account to pay the fee from.')
     }

--- a/src/lib/rpc-command.ts
+++ b/src/lib/rpc-command.ts
@@ -29,7 +29,7 @@ export abstract class RpcCommand extends Command {
         char: 'a',
         hidden: true,
       }),
-      'show-metadata': flags.boolean({
+      metadata: flags.boolean({
         char: 'm',
         description: 'Show returned metadata',
         default: false,
@@ -74,7 +74,7 @@ export abstract class RpcCommand extends Command {
     }
 
     protected showMetadataIfRequested(metadata: any, flags: Parser.flags.Output, description?: string) {
-      if (!flags['show-metadata']) return
+      if (!flags.metadata) return
       this.log(chalk.dim(`${description ? `${description} r` : 'R'}esponse metadata: %O`), metadata)
     }
 

--- a/src/lib/rpc.ts
+++ b/src/lib/rpc.ts
@@ -19,7 +19,7 @@ export class Socket extends WebsocketClient {
     .call(method, params || [], timeout, ws_opts)
     .then(result => {
       cli.action.stop()
-      return result
+      return (result as any).data
     })
     .catch(error => {
       if (error.data) throw new Error(`${error.message}: ${error.data}`)
@@ -64,7 +64,7 @@ export class Request {
       return response.json()
     })
     .then(data => {
-      if (data.result) return data.result
+      if (data.result) return data.result.data
       if (data.error) throw new Error(`${data.error.message}: ${data.error.data}`)
     })
   }

--- a/src/lib/rpc.ts
+++ b/src/lib/rpc.ts
@@ -10,8 +10,14 @@ type WebsocketOptions = {
   fin?: boolean;
 }
 
+export type RpcResponse<R> = {
+  data: R;
+  metadata?: Record<string, unknown>;
+}
+
 export class Socket extends WebsocketClient {
-  public async call(method: string, params?: IWSRequestParams, timeout?: number, ws_opts?: WebsocketOptions): Promise<unknown> {
+  public async call(method: string, params?: IWSRequestParams, timeout?: number, ws_opts?: WebsocketOptions):
+    Promise<RpcResponse<unknown>> {
     // Show loading spinner if no result after 1s
     const loaderTimeout = setTimeout(() => cli.action.start('Loading'), 1000)
 
@@ -19,7 +25,7 @@ export class Socket extends WebsocketClient {
     .call(method, params || [], timeout, ws_opts)
     .then(result => {
       cli.action.stop()
-      return (result as any).data
+      return result as RpcResponse<unknown>
     })
     .catch(error => {
       if (error.data) throw new Error(`${error.message}: ${error.data}`)
@@ -39,7 +45,7 @@ export class Request {
     private auth?: string,
   ) {}
 
-  public async call(method: string, params?: IWSRequestParams | undefined, _timeout?: number): Promise<unknown> {
+  public async call(method: string, params?: IWSRequestParams, _timeout?: number): Promise<RpcResponse<unknown>> {
     return fetch(this.url, {
       method: 'POST',
       headers: {
@@ -64,7 +70,7 @@ export class Request {
       return response.json()
     })
     .then(data => {
-      if (data.result) return data.result.data
+      if (data.result) return data.result
       if (data.error) throw new Error(`${data.error.message}: ${data.error.data}`)
     })
   }

--- a/src/lib/types/common.ts
+++ b/src/lib/types/common.ts
@@ -145,6 +145,6 @@ export type Validator = {
 }
 
 export type BlockchainState<T> = T & {
-    blockNumber: number,
-    blockHash: string,
+    blockNumber: number;
+    blockHash: string;
 }


### PR DESCRIPTION
This PR adds compatibility to the newest RPC Api changes in core-rs-albatross to be added by https://github.com/nimiq/core-rs-albatross/pull/1023.
The changes to the Api include a new format for RPC responses and subscriptions which now add optional metadata and scopes the main result into a 'data' sub-property.
The updated arpl client displays the scoped main result as it displayed the results prior to this change. Additionally, it can be optionally instructed to display the new metadata by supplying a new flag to each command.
These changes have been implemented in a backwards compatible fashion to old albatross clients prior to albatross PR 1023.

Albatross PR 1023 also renames methods create_update_transaction and send_update_transaction to create_update_staker_transaction and send_update_staker_transaction, which are thus also being renamed in this arpl PR.
This change is not backwards compatible.